### PR TITLE
FastJsonInput: do not repeat field value if null and previously not null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<groupId>com.trail2peak.pdi</groupId>
 	<artifactId>FastJsonInput</artifactId>
-	<version>1.0.4</version>
+	<version>1.0.5</version>
 	<name>FastJsonInput</name>
 
 

--- a/src/main/java/com/trail2peak/pdi/fastjsoninput/FastJsonInput.java
+++ b/src/main/java/com/trail2peak/pdi/fastjsoninput/FastJsonInput.java
@@ -527,13 +527,6 @@ public class FastJsonInput extends BaseStep implements StepInterface {
 			outputRowData[data.totalpreviousfields + i] = targetValueMeta
 					.convertData(sourceValueMeta, nodevalue);
 
-			// Do we need to repeat this field if it is null?
-			if (meta.getInputFields()[i].isRepeated()) {
-				if (data.previousRow != null && Const.isEmpty(nodevalue)) {
-					outputRowData[data.totalpreviousfields + i] = data.previousRow[data.totalpreviousfields
-							+ i];
-				}
-			}
 		} // End of loop over fields...
 
 		// When we have an input stream

--- a/src/test/java/com/trail2peak/pdi/fastjsoninput/FastJsonInputTest.java
+++ b/src/test/java/com/trail2peak/pdi/fastjsoninput/FastJsonInputTest.java
@@ -234,7 +234,12 @@ public class FastJsonInputTest extends TestCase {
         List<RowMetaAndData> transformationResults = test(myProperties.getProperty("NO_ID_AND_MISSING_CITY_JSON"), true, true);
         List<RowMetaAndData> expectedResults = createExpectedResults();
         try {
-            TestUtilities.checkRows(transformationResults, expectedResults, 0);
+            if (transformationResults.get(0).getData()[3] != null
+                && transformationResults.get(1).getData()[3] == null) {
+                TestUtilities.checkRows(transformationResults, expectedResults, 0);
+            } else {
+                fail("testNoIdAndMissingCityJson: The second city value was not null. Please investigate.");
+            }
         } catch(TestFailedException tfe) {
             fail(tfe.getMessage());
         }

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,4 +1,4 @@
 WELL_STRUCTURED_JSON=[{"id": "123", "first_name": "Jesse", "last_name": "Adametz", "city": "Santa Barbara"}, {"id": "456", "first_name": "James", "last_name": "Ebentier", "city": "Santa Barbara"}]
 MISSING_ID_JSON=[{"id": 123, "first_name": "Jesse", "last_name": "Adametz", "city": "Santa Barbara"}, {"first_name": "James", "last_name": "Ebentier", "city": "Santa Barbara"}]
 NO_ID_JSON=[{"first_name": "Jesse", "last_name": "Adametz", "city": "Santa Barbara"}, {"first_name": "James", "last_name": "Ebentier", "city": "Santa Barbara"}]
-NO_ID_AND_MISSING_CITY_JSON=[{"first_name": "Jesse", "last_name": "Adametz"}, {"first_name": "James", "last_name": "Ebentier", "city": "Santa Barbara"}]
+NO_ID_AND_MISSING_CITY_JSON=[{"first_name": "Jesse", "last_name": "Adametz", "city": "Santa Barbara"}, {"first_name": "James", "last_name": "Ebentier"}]

--- a/version.xml
+++ b/version.xml
@@ -1,1 +1,1 @@
-<version branch="Stable" buildId="">"1.0.4"</version>
+<version branch="Stable" buildId="">"1.0.5"</version>


### PR DESCRIPTION
Values in a column should not repeat the last non-null value when they are undefined.

Resolves #7